### PR TITLE
chore: sync generated content types, ignore local Claude settings

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -419,6 +419,20 @@ declare module 'astro:content' {
   collection: "posts";
   data: InferEntrySchema<"posts">
 } & { render(): Render[".mdoc"] };
+"en/the-case-for-boring-industrial-software.mdoc": {
+	id: "en/the-case-for-boring-industrial-software.mdoc";
+  slug: "en/the-case-for-boring-industrial-software";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
+"en/what-a-restaurant-needs-from-an-erp.mdoc": {
+	id: "en/what-a-restaurant-needs-from-an-erp.mdoc";
+  slug: "en/what-a-restaurant-needs-from-an-erp";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
 "es/future-of-edutech.mdoc": {
 	id: "es/future-of-edutech.mdoc";
   slug: "es/future-of-edutech";
@@ -426,9 +440,37 @@ declare module 'astro:content' {
   collection: "posts";
   data: InferEntrySchema<"posts">
 } & { render(): Render[".mdoc"] };
+"es/the-case-for-boring-industrial-software.mdoc": {
+	id: "es/the-case-for-boring-industrial-software.mdoc";
+  slug: "es/the-case-for-boring-industrial-software";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
+"es/what-a-restaurant-needs-from-an-erp.mdoc": {
+	id: "es/what-a-restaurant-needs-from-an-erp.mdoc";
+  slug: "es/what-a-restaurant-needs-from-an-erp";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
 "ms/future-of-edutech.mdoc": {
 	id: "ms/future-of-edutech.mdoc";
   slug: "ms/future-of-edutech";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
+"ms/the-case-for-boring-industrial-software.mdoc": {
+	id: "ms/the-case-for-boring-industrial-software.mdoc";
+  slug: "ms/the-case-for-boring-industrial-software";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
+"ms/what-a-restaurant-needs-from-an-erp.mdoc": {
+	id: "ms/what-a-restaurant-needs-from-an-erp.mdoc";
+  slug: "ms/what-a-restaurant-needs-from-an-erp";
   body: string;
   collection: "posts";
   data: InferEntrySchema<"posts">

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 /src/images/resources
 
 /dist
+
+# Per-machine Claude Code settings
+.claude/settings.local.json


### PR DESCRIPTION
Found during a workspace cleanup.

`.astro/types.d.ts` is tracked but had drifted behind the content collection — it was missing the entry for `the-case-for-boring-industrial-software`, which is committed in all three locales (`en`/`es`/`ms`). Regenerated, so a fresh checkout type-checks without first running the dev server.

Also ignores `.claude/settings.local.json`, which is per-machine.

Two untracked files were also removed from the working tree in the same pass — not part of this diff since neither was ever committed:
- `astro.config.verify.mts` — self-labelled "TEMPORARY sandbox-verification config — safe to delete"
- `team-photo.png` at the repo root — sha1-identical duplicate of the tracked `src/assets/pages/about/team-photo.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Atelier-Optimatix/codesmith/atelieroptimatix.com/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787806736&installation_model_id=426887&pr_number=25&repository=Atelier-Optimatix%2Fatelieroptimatix.com&return_to=https%3A%2F%2Fgithub.com%2FAtelier-Optimatix%2Fatelieroptimatix.com%2Fpull%2F25&signature=1c48c1aeef1f0532c0c0c8eddd62cf9aee84279379c55a8ced77a4081baccc96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->