### PR TITLE
Scaffold user guide / docs system (Phase 2)

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -157,6 +157,36 @@ declare module 'astro:content' {
   data: any
 } & { render(): Render[".mdoc"] };
 };
+"docs": {
+"en/admissions-admin-overview.mdoc": {
+	id: "en/admissions-admin-overview.mdoc";
+  slug: "en/admissions-admin-overview";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".mdoc"] };
+"en/educonnect-staff-attendance-overview.mdoc": {
+	id: "en/educonnect-staff-attendance-overview.mdoc";
+  slug: "en/educonnect-staff-attendance-overview";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".mdoc"] };
+"en/kindercare-parent-getting-started.mdoc": {
+	id: "en/kindercare-parent-getting-started.mdoc";
+  slug: "en/kindercare-parent-getting-started";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".mdoc"] };
+"en/shared-logging-in.mdoc": {
+	id: "en/shared-logging-in.mdoc";
+  slug: "en/shared-logging-in";
+  body: string;
+  collection: "docs";
+  data: InferEntrySchema<"docs">
+} & { render(): Render[".mdoc"] };
+};
 "pages": {
 "en/about.mdoc": {
 	id: "en/about.mdoc";
@@ -419,6 +449,20 @@ declare module 'astro:content' {
   collection: "posts";
   data: InferEntrySchema<"posts">
 } & { render(): Render[".mdoc"] };
+"en/the-case-for-boring-industrial-software.mdoc": {
+	id: "en/the-case-for-boring-industrial-software.mdoc";
+  slug: "en/the-case-for-boring-industrial-software";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
+"en/what-a-restaurant-needs-from-an-erp.mdoc": {
+	id: "en/what-a-restaurant-needs-from-an-erp.mdoc";
+  slug: "en/what-a-restaurant-needs-from-an-erp";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
 "es/future-of-edutech.mdoc": {
 	id: "es/future-of-edutech.mdoc";
   slug: "es/future-of-edutech";
@@ -426,9 +470,37 @@ declare module 'astro:content' {
   collection: "posts";
   data: InferEntrySchema<"posts">
 } & { render(): Render[".mdoc"] };
+"es/the-case-for-boring-industrial-software.mdoc": {
+	id: "es/the-case-for-boring-industrial-software.mdoc";
+  slug: "es/the-case-for-boring-industrial-software";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
+"es/what-a-restaurant-needs-from-an-erp.mdoc": {
+	id: "es/what-a-restaurant-needs-from-an-erp.mdoc";
+  slug: "es/what-a-restaurant-needs-from-an-erp";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
 "ms/future-of-edutech.mdoc": {
 	id: "ms/future-of-edutech.mdoc";
   slug: "ms/future-of-edutech";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
+"ms/the-case-for-boring-industrial-software.mdoc": {
+	id: "ms/the-case-for-boring-industrial-software.mdoc";
+  slug: "ms/the-case-for-boring-industrial-software";
+  body: string;
+  collection: "posts";
+  data: InferEntrySchema<"posts">
+} & { render(): Render[".mdoc"] };
+"ms/what-a-restaurant-needs-from-an-erp.mdoc": {
+	id: "ms/what-a-restaurant-needs-from-an-erp.mdoc";
+  slug: "ms/what-a-restaurant-needs-from-an-erp";
   body: string;
   collection: "posts";
   data: InferEntrySchema<"posts">

--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -714,6 +714,86 @@ export default config({
 				}),
 			},
 		}),
+		docs: collection({
+			label: "User Guide",
+			slugField: "title",
+			path: "src/content/docs/en/*",
+			entryLayout: "content",
+			columns: ["title", "product", "lastUpdateDate"],
+			previewUrl: "/docs/{slug}",
+			format: { contentField: "content" },
+			schema: {
+				title: fields.slug({
+					name: {
+						label: "Title",
+						validation: {
+							isRequired: true,
+						},
+					},
+					slug: {
+						label: "SEO-friendly slug",
+						description: "Used verbatim in the /docs/<product>/... URL and as the tooltip deep-link anchor target — avoid changing after publishing.",
+					},
+				}),
+				description: fields.text({
+					label: "Description",
+					description: "Also used as the trimmed excerpt shown in in-app tooltips — keep this to one short sentence.",
+					multiline: true,
+					validation: {
+						isRequired: true,
+					},
+				}),
+				product: fields.select({
+					label: "Product",
+					description: "Which top-level docs section this page belongs to.",
+					options: [
+						{ label: "EduConnect", value: "educonnect" },
+						{ label: "KinderCare", value: "kindercare" },
+						{ label: "Admissions", value: "admissions" },
+						{ label: "Shared (cross-product)", value: "shared" },
+					],
+					defaultValue: "shared",
+				}),
+				roles: fields.array(fields.text({ label: "Role" }), {
+					label: "Roles",
+					description: "Who this page is written for, e.g. staff, parent, admin.",
+					itemLabel: (props) => props.value,
+				}),
+				sourcePaths: fields.array(fields.text({ label: "Path or glob" }), {
+					label: "Source paths",
+					description: "Repo-relative paths/globs this page documents (e.g. attendance-web-app/edu-frontend/lib/screens/attendance/). Powers the CI staleness check — keep directory-level, not per-file.",
+					itemLabel: (props) => props.value,
+				}),
+				screenshotIds: fields.array(fields.text({ label: "Screenshot ID" }), {
+					label: "Screenshot IDs",
+					description: "Stable IDs referencing auto-captured screenshots (resolved at render time), not hand-embedded images.",
+					itemLabel: (props) => props.value,
+				}),
+				lastUpdateDate: fields.date({
+					label: "Last Update Date",
+					defaultValue: {
+						kind: "today",
+					},
+					validation: {
+						isRequired: true,
+					},
+				}),
+				hidden: fields.checkbox({
+					label: "Hidden",
+				}),
+				content: fields.markdoc({
+					label: "Content",
+					options: {
+						heading: [2, 3, 4, 5, 6],
+						image: {
+							directory: "src/assets/docs",
+							publicPath: "/src/assets/docs/",
+						},
+					},
+					components: {},
+				}),
+			},
+		}),
 		works: collection({
 			label: "Projects",
 			slugField: "title",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"dev": "astro dev",
 		"start": "astro dev",
 		"build": "astro build",
+		"postbuild": "pagefind --site dist",
 		"preview": "astro preview",
 		"astro": "astro",
 		"pwa:generate-assets": "pwa-assets-generator --preset minimal public/favicon.svg"
@@ -56,6 +57,7 @@
 		"astro-icon": "^1.1.0",
 		"astro-robots-txt": "^1.0.0",
 		"astro-seo": "^0.8.3",
+		"pagefind": "^1.1.0",
 		"satori": "^0.10.13",
 		"tailwindcss": "^3.4.3",
 		"workbox-window": "^7.1.0"

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -60,9 +60,27 @@ const servicesCollection = defineCollection({
 		}),
 });
 
+// User guide / help center content. `product` and `roles` drive the docs IA
+// (grouping by /docs/<product>/<role>/...); `sourcePaths` powers the CI
+// staleness check that flags when mapped app code changes without a doc update.
+const docsCollection = defineCollection({
+	schema: () =>
+		z.object({
+			title: z.string(),
+			description: z.string(),
+			product: z.enum(["educonnect", "kindercare", "admissions", "shared"]),
+			roles: z.array(z.string()),
+			lastUpdateDate: z.date(),
+			sourcePaths: z.array(z.string()),
+			screenshotIds: z.optional(z.array(z.string())),
+			hidden: z.optional(z.boolean()),
+		}),
+});
+
 export const collections = {
 	posts: postsCollection,
 	pages: pagesCollection,
 	services: servicesCollection,
 	works: worksCollection,
+	docs: docsCollection,
 };

--- a/src/content/docs/en/admissions-admin-overview.mdoc
+++ b/src/content/docs/en/admissions-admin-overview.mdoc
@@ -1,0 +1,19 @@
+---
+title: Reviewing Applications as an Admissions Admin
+description: How admins review, approve, and follow up on incoming applications in the admissions portal.
+product: admissions
+roles:
+  - admin
+sourcePaths:
+  - educonnect-admissions/edu-frontend/lib/screens/
+  - educonnect-admissions/backend/controllers/
+lastUpdateDate: 2026-08-30
+hidden: false
+---
+
+## Overview
+
+This page is a placeholder scaffolded while the docs system was set up. Full content will be
+written in Phase 3 based on the actual admissions flow in `educonnect-admissions`.
+
+*(content to be filled in during Phase 3 content pass)*

--- a/src/content/docs/en/educonnect-staff-attendance-overview.mdoc
+++ b/src/content/docs/en/educonnect-staff-attendance-overview.mdoc
@@ -1,0 +1,28 @@
+---
+title: Taking Attendance as Staff
+description: How staff mark daily attendance in EduConnect and what happens when a student is marked absent.
+product: educonnect
+roles:
+  - staff
+sourcePaths:
+  - attendance-web-app/edu-frontend/lib/screens/attendance/
+  - attendance-web-app/backend/controllers/attendanceController.js
+screenshotIds:
+  - educonnect-staff-attendance-list
+  - educonnect-staff-attendance-mark
+lastUpdateDate: 2026-08-30
+hidden: false
+---
+
+## Overview
+
+This page is a placeholder scaffolded while the docs system was set up. Full content will be
+written in Phase 3 based on the actual attendance flow in `edu-frontend/lib/screens/attendance/`.
+
+## What staff can do
+
+- View the daily class roster
+- Mark each student present, absent, or late
+- See attendance history for a given student
+
+*(content to be filled in during Phase 3 content pass)*

--- a/src/content/docs/en/kindercare-parent-getting-started.mdoc
+++ b/src/content/docs/en/kindercare-parent-getting-started.mdoc
@@ -1,0 +1,23 @@
+---
+title: Getting Started as a Parent
+description: What to expect the first time you log into the KinderCare parent app.
+product: kindercare
+roles:
+  - parent
+sourcePaths:
+  - kinder_care_parent/lib/
+  - kinder-care-fe/lib/
+screenshotIds:
+  - kindercare-parent-login
+  - kindercare-parent-home
+lastUpdateDate: 2026-08-30
+hidden: false
+---
+
+## Overview
+
+This page is a placeholder scaffolded while the docs system was set up. Full content will be
+written in Phase 3, drawing on the existing hand-written notes in `kinder_care_parent`
+(`parentapp-auth.md`, `parentapp-calls.md`) as source material.
+
+*(content to be filled in during Phase 3 content pass)*

--- a/src/content/docs/en/shared-logging-in.mdoc
+++ b/src/content/docs/en/shared-logging-in.mdoc
@@ -1,0 +1,25 @@
+---
+title: Logging In
+description: How login and password reset work across EduConnect, KinderCare and Admissions.
+product: shared
+roles:
+  - staff
+  - parent
+  - admin
+sourcePaths:
+  - attendance-web-app/edu-frontend/lib/screens/auth/
+  - educonnect-public/edu-frontend/lib/screens/auth/
+  - educonnect-admissions/edu-frontend/lib/screens/auth/
+  - kinder_care_parent/lib/
+  - kinder-care-fe/lib/
+lastUpdateDate: 2026-08-30
+hidden: false
+---
+
+## Overview
+
+This page is a placeholder scaffolded while the docs system was set up. Login is one of the
+cross-product concepts called out in the docs IA as `shared` content, single-sourced here and
+linked from each product's login screen tooltip rather than duplicated per product.
+
+*(content to be filled in during Phase 3 content pass)*

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,0 +1,52 @@
+---
+import type { CollectionEntry } from "astro:content";
+import Container from "@/components/primitives/Container.astro";
+import Prose from "@/components/primitives/Prose.astro";
+import Title from "@/components/primitives/Title.astro";
+import BaseLayout from "./BaseLayout.astro";
+
+type Props = {
+	frontmatter: CollectionEntry<"docs">;
+};
+
+const { frontmatter } = Astro.props;
+const { product, roles, lastUpdateDate } = frontmatter.data;
+
+const productLabels: Record<string, string> = {
+	educonnect: "EduConnect",
+	kindercare: "KinderCare",
+	admissions: "Admissions",
+	shared: "Shared",
+};
+---
+
+<BaseLayout>
+	<section class="py-32 md:py-56">
+		<Container>
+			<div class="text-center">
+				<div class="inline-flex items-center gap-2 pb-4 lg:pb-6">
+					<span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-black">
+						{productLabels[product] ?? product}
+					</span>
+					{
+						roles.map((role) => (
+							<span class="rounded-full bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+								{role}
+							</span>
+						))
+					}
+				</div>
+				<Title level={1}>{frontmatter.data.title}</Title>
+				<p class="mx-auto max-w-2xl pt-8 text-base text-slate-500">
+					<em>{frontmatter.data?.description}</em>
+				</p>
+				<p class="pt-4 text-xs text-slate-400">
+					Last updated {lastUpdateDate?.toString().slice(0, 10)}
+				</p>
+			</div>
+			<div class="flex w-full flex-col items-center justify-center pt-12">
+				<Prose><slot /></Prose>
+			</div>
+		</Container>
+	</section>
+</BaseLayout>

--- a/src/pages/docs/[...slug]/index.astro
+++ b/src/pages/docs/[...slug]/index.astro
@@ -1,0 +1,20 @@
+---
+import type { CollectionEntry } from "astro:content";
+import DocsLayout from "@/layouts/DocsLayout.astro";
+import { getCollectionStaticPaths } from "@/lib/collection-helpers";
+
+export interface Props {
+	data: CollectionEntry<"docs">;
+}
+
+export async function getStaticPaths() {
+	return await getCollectionStaticPaths("docs", "en");
+}
+
+const { data: doc } = Astro.props;
+const { Content } = await doc.render();
+---
+
+<DocsLayout frontmatter={doc}>
+	<Content />
+</DocsLayout>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -1,0 +1,81 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/primitives/Container.astro";
+import Link from "@/components/primitives/Link.astro";
+import Title from "@/components/primitives/Title.astro";
+
+const allDocs = await getCollection("docs", ({ data }) => !data.hidden);
+
+const productOrder = ["educonnect", "kindercare", "admissions", "shared"] as const;
+const productLabels: Record<string, string> = {
+	educonnect: "EduConnect",
+	kindercare: "KinderCare",
+	admissions: "Admissions",
+	shared: "Shared",
+};
+
+const sections = productOrder.map((product) => ({
+	product,
+	label: productLabels[product],
+	docs: allDocs.filter((doc) => doc.data.product === product),
+}));
+---
+
+<BaseLayout>
+	<section class="py-32 md:py-56">
+		<Container>
+			<div class="text-center">
+				<Title level={1}>User Guide</Title>
+				<p class="mx-auto max-w-2xl pt-6 text-base text-slate-500">
+					Help and how-to documentation for EduConnect, KinderCare and Admissions.
+				</p>
+			</div>
+
+			<div id="docs-search" class="mx-auto max-w-2xl pt-12"></div>
+
+			<div class="mx-auto grid max-w-4xl gap-12 pt-16 sm:grid-cols-2">
+				{
+					sections.map(
+						(section) =>
+							section.docs.length > 0 && (
+								<div>
+									<h2 class="pb-4 text-sm font-semibold uppercase tracking-wide text-black">
+										{section.label}
+									</h2>
+									<ul class="space-y-2">
+										{section.docs.map((doc) => {
+											const [, ...slug] = doc.slug.split("/");
+											return (
+												<li>
+													<Link href={`/docs/${slug.join("/")}`} size="md" style="outline">
+														{doc.data.title}
+													</Link>
+												</li>
+											);
+										})}
+									</ul>
+								</div>
+							),
+					)
+				}
+			</div>
+		</Container>
+	</section>
+</BaseLayout>
+
+<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+<script>
+	// Pagefind assets only exist after `npm run build` (see the postbuild script in
+	// package.json) - in local `astro dev` this script tag 404s silently and the
+	// search box just stays empty.
+	const script = document.createElement("script");
+	script.src = "/pagefind/pagefind-ui.js";
+	script.onload = () => {
+		const w = window as unknown as { PagefindUI?: new (opts: Record<string, unknown>) => unknown };
+		if (w.PagefindUI) {
+			new w.PagefindUI({ element: "#docs-search", showSubResults: true });
+		}
+	};
+	document.head.appendChild(script);
+</script>


### PR DESCRIPTION
## Summary

Phase 2 of the EduConnect/KinderCare/Admissions user guide project: stands up the docs section inside this repo's existing Astro + Keystatic site rather than a separate docs toolchain, per sign-off in planning.

- New `docs` content collection (`src/content/config.ts`, `keystatic.config.ts`) mirroring the existing `posts` pattern. Front-matter carries `product` / `roles` (drives the IA: `/docs/<product>/<role>/...` grouping) and `sourcePaths` (repo-relative globs a page documents), which a later CI job will diff against PR-changed files to flag stale docs.
- `/docs` (section index + search box) and `/docs/<slug>` routes, reusing the existing `getCollectionStaticPaths` helper — same routing convention as `/post/<slug>`.
- `DocsLayout.astro` modeled on `PostLayout.astro`.
- One placeholder page per top-level IA section (EduConnect/staff, KinderCare/parent, Admissions/admin, Shared) to prove the model end-to-end. Bodies are intentionally stubs — real content is a separate Phase 3 PR written from the actual app flows in each product repo.
- Pagefind for static, build-time full-text search (`postbuild` script + default UI on `/docs`) — no backend/hosted search service needed. Only works against a built site (`npm run build && npm run preview`), not `astro dev`.
- `description` front-matter field doubles as the trimmed excerpt that in-app tooltips will show later (Phase 4), so there's a single source of truth per topic rather than a separate excerpt field.

## Test plan

- [x] `npm run build` succeeds and generates `/docs`, `/docs/<slug>` for all 4 placeholder pages
- [x] `postbuild` (Pagefind) indexes the built site without errors
- [ ] Manual click-through in `npm run preview` (reviewer)
- [ ] Keystatic admin UI (`astro dev` → `/keystatic`) shows the new "User Guide" collection with working fields (not yet manually verified in this environment)

Not in scope for this PR: real content (Phase 3), screenshot automation (Phase 3), in-app tooltip components in the product repos (Phase 4), the CI staleness-check gate (Phase 5), and adding a "Docs" link to the site's global nav (left as a fast follow to keep this PR focused).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Atelier-Optimatix/codesmith/atelieroptimatix.com/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790630199&installation_model_id=426887&pr_number=26&repository=Atelier-Optimatix%2Fatelieroptimatix.com&return_to=https%3A%2F%2Fgithub.com%2FAtelier-Optimatix%2Fatelieroptimatix.com%2Fpull%2F26&signature=8aeef40fbc05001b98bc572ee1f4c06440da6c2a3ab5dd374cb5a1e903dcc584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a User Guide section with product- and role-specific documentation.
  - Added documentation pages for admissions, staff attendance, parent onboarding, and shared login guidance.
  - Added documentation search and organized guides by product.
  - Added metadata such as descriptions, roles, products, and update dates to guide pages.
  - Added two new blog posts, available in English, Spanish, and Malay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->