### PR TITLE
Publish docs tooltip manifest for in-app help widgets

### DIFF
--- a/src/pages/docs/tooltips.json.ts
+++ b/src/pages/docs/tooltips.json.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { defaultLocale } from "site.config";
+
+// Published for in-app help tooltips (attendance-web-app, educonnect-public,
+// educonnect-admissions) to fetch at runtime. Generated straight from the
+// `docs` content collection so the excerpt shown in-app is never a
+// hand-copied duplicate of the doc's `description` front-matter - this is
+// the single source for both the full page and the tooltip text.
+export const GET: APIRoute = async () => {
+	const allDocs = await getCollection("docs", ({ data }) => !data.hidden);
+
+	const entries = allDocs
+		.filter((doc) => doc.slug.startsWith(`${defaultLocale}/`))
+		.map((doc) => ({
+			slug: doc.slug.slice(defaultLocale.length + 1),
+			title: doc.data.title,
+			description: doc.data.description,
+			product: doc.data.product,
+		}));
+
+	return new Response(JSON.stringify(entries), {
+		headers: { "Content-Type": "application/json" },
+	});
+};


### PR DESCRIPTION
## Summary

**Depends on #26 (docs scaffold)** — based on `user-guides/docs-scaffold` since it needs the `docs` content collection. Merge #26 first, then retarget this at `main`.

Part of Phase 4 (in-app help tooltips) of the user guide project. Adds a build-time JSON endpoint, `/docs/tooltips.json`, generated straight from the `docs` content collection: `[{ slug, title, description, product }]` for every non-hidden doc.

This is what the three product apps' new `HelpTooltip` widgets fetch at runtime (see the companion PRs in attendance-web-app, educonnect-public, and educonnect-admissions) to show a short excerpt inline before linking out to the full page. Generating it from the collection — rather than having each app hardcode excerpt strings — keeps `description` single-sourced: edit a `.mdoc` file once and every app's tooltip picks it up on its next fetch, no code change anywhere.

## Test plan

- [x] `npm run build` succeeds
- [x] `dist/docs/tooltips.json` generated correctly, matches the current (placeholder, pre-#27) doc set — confirmed via `cat`
- [ ] Once #27 merges, spot-check the manifest includes all 11 real topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Atelier-Optimatix/codesmith/atelieroptimatix.com/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790657745&installation_model_id=426887&pr_number=28&repository=Atelier-Optimatix%2Fatelieroptimatix.com&return_to=https%3A%2F%2Fgithub.com%2FAtelier-Optimatix%2Fatelieroptimatix.com%2Fpull%2F28&signature=c11c1f600c52e7d231c384add05d4b73afeed593a43babc645a5a9966fd9379a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->